### PR TITLE
Fix for dartformat_task

### DIFF
--- a/lib/src/dartformat_task.dart
+++ b/lib/src/dartformat_task.dart
@@ -5,7 +5,7 @@ import 'package:grinder/grinder.dart';
 /// Check whether all *.dart files in the given directories and their sub-
 /// directories are properly formatted.
 void checkFormatTask(Iterable<String> directories) {
-  final output = PubApp.global('dart_style')
+  final output = new PubApp.global('dart_style')
       .run(['--dry-run']..addAll(directories), script: 'format');
   if (output.split('\n').where((l) => l.isNotEmpty).isNotEmpty) {
     context.fail('Some files are not properly formatted.');


### PR DESCRIPTION
Simple fix, as it didn't originally work for me. Changing ```PubApp.global('dart_style')``` to ```new PubApp.global('dart_style')``` fixed the problem.

(Sadly it didn't fix the bugs it raised in github.com/dart-lang/dart_style as it tried to run it)